### PR TITLE
DragAndDropState

### DIFF
--- a/app/components/Containers/EventContainers/DragAndDrop/DragContainer/index.js
+++ b/app/components/Containers/EventContainers/DragAndDrop/DragContainer/index.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { bindActionCreators }  from 'redux';
+import { connect } from 'react-redux';
+
+import Draggable from '../../Draggable';
+
+import { dragAndDropActions, dragAndDropTypes } from '../../../../../state/mouse/dragAndDrop';
+
+const DragContainer = React.createClass({
+	propTypes: {
+		dragId: React.PropTypes.string.isRequired,
+		zoneId: React.PropTypes.string.isRequired
+	},
+
+	componentWillMount() {
+		this.props.createDraggable(this.props.dragId, this.props.zoneId);
+	},
+
+	toggleSelect() {
+		this.isDragging = !this.isDragging;
+		
+		if(this.isDragging) {
+			this.props.selectDraggable(this.props.dragId);
+		}
+		else
+		{
+			this.props.selectDraggable();
+		}
+	},
+
+	render() {
+		return (
+			<div onMouseUp={this.toggleSelect}>
+				<Draggable initialX={50} initialY={50}>
+					{this.props.children}
+				</Draggable>
+			</div>
+		)
+	}
+});
+
+function mapStateToProps(store) {
+	return {
+		dragAndDropState: store.dragAndDropState
+	};
+}
+
+function mapDispatchToProps(dispatch) {
+	return bindActionCreators({
+		createDraggable: dragAndDropActions.createDraggable,
+		selectDraggable: dragAndDropActions.selectDraggable
+	}, dispatch)
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(DragContainer);

--- a/app/components/Containers/EventContainers/DragAndDrop/DropZone/index.js
+++ b/app/components/Containers/EventContainers/DragAndDrop/DropZone/index.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { bindActionCreators }  from 'redux';
+import { connect } from 'react-redux';
+
+import { dragAndDropActions, dragAndDropTypes } from '../../../../../state/mouse/dragAndDrop';
+
+const DropZone = React.createClass({
+	propTypes: {
+		zoneId: React.PropTypes.string.isRequired
+	},
+
+	componentWillMount() {
+		this.props.createDropZone(this.props.zoneId);
+
+		this.userIsHovering = false;
+		this.lastHoverCase = false;
+	},
+
+	componentDidMount() {
+		this.domElement = ReactDOM.findDOMNode(this);
+		this.boundingBox = this.domElement.getBoundingClientRect();
+	},
+
+	componentWillReceiveProps() {
+		this.lastHoverCase = this.userIsHovering;
+
+		if(this.props.mouseState.position.x > this.boundingBox.left &&
+			this.props.mouseState.position.x < this.boundingBox.right &&
+			this.props.mouseState.position.y > this.boundingBox.top &&
+			this.props.mouseState.position.y < this.boundingBox.bottom) {
+
+			if(!this.userIsHovering){
+				this.userIsHovering = true;
+			}
+		}
+		else
+		{
+			if(this.userIsHovering) {
+				this.userIsHovering = false;
+			}
+		}
+	},
+
+	shouldComponentUpdate(nextProps) {
+		if(this.userIsHovering != this.lastHoverCase) {
+			return true;
+		}
+		else
+		{
+			return false;
+		}
+	},
+
+	componentWillUpdate() {
+		if(this.userIsHovering) {
+			this.enterZone();
+		}
+		else
+		{
+			this.leaveZone();
+		}
+	},
+
+	enterZone() {
+		this.props.selectDropZone(this.props.zoneId);
+	},
+
+	leaveZone() {
+		this.props.selectDropZone();
+	},
+
+	render() {
+		return (
+			<div>
+				{this.props.children}
+			</div>
+		)
+	}
+});
+
+function mapStateToProps(store) {
+	return {
+		dragAndDropState: store.dragAndDropState,
+		mouseState: store.mouseState
+	};
+}
+
+function mapDispatchToProps(dispatch) {
+	return bindActionCreators({
+		createDropZone: dragAndDropActions.createDropZone,
+		selectDropZone: dragAndDropActions.selectDropZone
+	}, dispatch)
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(DropZone);

--- a/app/components/Containers/EventContainers/Draggable/index.js
+++ b/app/components/Containers/EventContainers/Draggable/index.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import { mouseTrackingActions, mouseTrackingTypes } from '../../../../state/mouse/tracking';
+
+const Draggable = React.createClass({
+	propTypes: {
+		mouseState: React.PropTypes.object.isRequired
+	},
+
+	componentDidMount() {
+		this.dragging = false;
+		this.domElement = ReactDOM.findDOMNode(this);
+		this.originalPosition = {
+			position: this.domElement.style.position,
+			top: this.domElement.style.top,
+			left: this.domElement.style.left
+		}
+	},
+
+	toggleDrag() {
+		this.dragging = !this.dragging;
+
+		if(this.dragging) {
+			this.domElement.style.position = 'absolute';
+			window.addEventListener('mousemove', this.trackMouse);
+		}
+		else
+		{	
+			window.removeEventListener('mousemove', this.trackMouse);
+			this.props.clearMousePosition();
+
+			if(!this.props.dragAndDropState.canDrop) {
+				this.returnDraggableToOriginalPosition();
+			}
+		}
+	},
+
+	startTrackingMouse() {		
+		window.addEventListener('mousemove', this.trackMouse);
+	},
+
+	stopTrackingMouse() {
+		window.removeEventListener('mousemove', this.trackMouse);
+	},
+
+	trackMouse(event) {
+		this.props.trackMousePosition(event.clientX, event.clientY);
+		this.domElement.style.top = this.props.mouseState.position.y - (this.domElement.getBoundingClientRect().height / 2) + 'px';
+		this.domElement.style.left = this.props.mouseState.position.x - (this.domElement.getBoundingClientRect().width / 2) + 'px';
+	},
+
+	returnDraggableToOriginalPosition() {
+		this.domElement.style.position = this.originalPosition.position;
+		this.domElement.style.top = this.originalPosition.top;
+		this.domElement.style.left = this.originalPosition.left;		
+	},
+
+	render() {
+		return (
+			<div>
+				<div onMouseUp={this.toggleDrag}>
+					{this.props.children}
+				</div>
+			
+			</div>
+		)
+	}
+});
+
+function mapStateToProps(store) {
+	return {
+		mouseState: store.mouseState,
+		dragAndDropState: store.dragAndDropState
+	};
+}
+
+function mapDispatchToProps(dispatch) {
+	return bindActionCreators({
+		trackMousePosition: mouseTrackingActions.trackMousePosition,
+		clearMousePosition: mouseTrackingActions.clearMousePosition
+	}, dispatch)
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Draggable);

--- a/app/components/Containers/index.js
+++ b/app/components/Containers/index.js
@@ -1,6 +1,10 @@
 export { default as StickyContainer } from './EventContainers/StickyEventContainer';
 export { default as ScrollLoader } from './EventContainers/ScrollLoader';
 export { default as TimedContainer } from './EventContainers/TimedContainer';
+export { default as Draggable } from './EventContainers/Draggable';
+
+export { default as DragContainer } from './EventContainers/DragAndDrop/DragContainer';
+export { default as DropZone } from './EventContainers/DragAndDrop/DropZone';
 
 export { default as ResponsiveContainer } from './LayoutContainers/ResponsiveContainer';
 

--- a/app/components/Layout/Navbar/index.js
+++ b/app/components/Layout/Navbar/index.js
@@ -14,4 +14,4 @@ const MainNavbar = React.createClass({
 	}
 });
 
-export default MainNavbar
+export default MainNavbar;

--- a/app/components/Pages/Home/index.js
+++ b/app/components/Pages/Home/index.js
@@ -8,12 +8,10 @@ export default class Home extends React.Component {
 			<ResponsiveContainer>
 				<h1>SUP HOMEBOY!</h1>
 
-				<TimedContainer tcDelay={5} tcIncrement={500} tcDuration={4}>
+				<TimedContainer tcDelay={5} tcIncrement={2000} tcDuration={4}>
 
 				</TimedContainer>
 
-
-				<h1>Aliquam fermentum, diam nec tincidunt condimentum, justo purus aliquam risus, et vestibulum orci turpis a justo. Quisque augue ante, lacinia vitae sapien non, tristique finibus lorem. Nam tortor turpis, auctor non risus vel, maximus placerat enim. In nisl nibh, condimentum quis ante sit amet, vehicula placerat enim. Aliquam finibus pretium lacus, ut mollis nisl ornare ac. Donec elementum arcu massa, at consequat eros luctus a. Suspendisse tincidunt finibus tincidunt. Aenean finibus rhoncus scelerisque. Aliquam erat volutpat. In fringilla sodales augue quis aliquam. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Aliquam viverra ultrices arcu, at sollicitudin mauris luctus sit amet.</h1>
 				<Grid gutter={5} breakPoints={[1100, 800, 600]}>
 					<Row blocks={5}>
 						<Col blocks={2} breaks={[100]}>
@@ -38,36 +36,7 @@ export default class Home extends React.Component {
 							<p>POOP</p>
 						</Col>
 					</Row>
-					<Row blocks={5}>
-						<Col blocks={2} breaks={[100]}>
-							<p>
-								Aliquam fermentum, diam nec tincidunt condimentum, justo purus aliquam risus, et vestibulum orci turpis a justo. Quisque augue ante, lacinia vitae sapien non, tristique finibus lorem. Nam tortor turpis, auctor non risus vel, maximus placerat enim. In nisl nibh, condimentum quis ante sit amet, vehicula placerat enim. Aliquam finibus pretium lacus, ut mollis nisl ornare ac. Donec elementum arcu massa, at consequat eros luctus a. Suspendisse tincidunt finibus tincidunt. Aenean finibus rhoncus scelerisque. Aliquam erat volutpat. In fringilla sodales augue quis aliquam. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Aliquam viverra ultrices arcu, at sollicitudin mauris luctus sit amet.
-							</p>
-						</Col>
-						<Col breaks={[33.3, 33.3, 100]}>
-							<p>
-								Aliquam fermentum, diam nec tincidunt condimentum, justo purentum arcu massa, at consequat eros luctus a. Suspendisse tincidunt finibus tincidunt.
-							</p>
-							<p>
-								Aenean finibus rhoncus scelerisque. Aliquam erat volutpat. In fringilla sodales augue quis aliquam. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Aliquam viverra ultrices arcu, at sollicitudin mauris luctus sit amet.
-							</p>						
-						</Col>
-						<Col breaks={[33.3, 33.3, 100]}>
-							<p>
-								Aliquam fermentum, diam nec tincidunt condimentum, justo purus aliquam risus, et vestibulum orci turpis a justo. Quisque augue ante, lacinia vitae sapien non, tristique finibus lorem. Nam tortor turpis, auctor non risus vel, maximus placerat enim. In nisl nibh, condimentum quis ante sit amet, vehicula placerat enim. Aliquam finibus pretium lacus, ut mollis nisl ornare ac. Donec elementum arcu massa, at consequat eros luctus a. Suspendisse tincidunt finibus tincidunt. Aenean finibus rhoncus scelerisque. Aliquam erat volutpat. In fringilla sodales augue quis aliquam. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Aliquam viverra ultrices arcu, at sollicitudin mauris luctus sit amet.
-							</p>
-						</Col>
-						<Col breaks={[33.3, 33.3, 100]}>
-							<p>POOP</p>
-						</Col>
-					</Row>
 				</Grid>
-				<ScrollLoader>
-					<img src={require('./images/bunnies.jpg')} style={{width: '100%'}}/>
-					<img src={require('./images/bunnies.jpg')} style={{width: '100%'}}/>
-					<img src={require('./images/bunnies.jpg')} style={{width: '100%'}}/>
-					<img src={require('./images/bunnies.jpg')} style={{width: '100%'}}/>
-				</ScrollLoader>
 			</ResponsiveContainer>
 		)
 	}

--- a/app/components/Pages/Portfolio/index.js
+++ b/app/components/Pages/Portfolio/index.js
@@ -1,11 +1,21 @@
 import React from 'react';
-import { ResponsiveContainer } from '../../Containers';
+import { ResponsiveContainer, DragContainer, DropZone } from '../../Containers';
 
 export default class PortfolioPage extends React.Component {
 	render() {
 		return (
 			<ResponsiveContainer>
-				<h1>Portfolio Page, Sucka!</h1>
+				<DragContainer dragId={'greenGuy'} zoneId={'yellowBox'}>
+					<p>
+						POOP
+					</p>
+				</DragContainer>
+
+				<DropZone zoneId={'yellowBox'}>
+					<p>
+						FARTS
+					</p>
+				</DropZone>
 			</ResponsiveContainer>
 		)
 	}

--- a/app/state/events/scroll/duck/actions.js
+++ b/app/state/events/scroll/duck/actions.js
@@ -1,12 +1,14 @@
 import types from './types';
 
-const getScrollPosition = () => ({
-	type: types.GET_SCROLL_POSITION,
-	payload: {
-		scrollX: window.scrollX,
-		scrollY: window.scrollY
+function getScrollPosition() {
+	return {
+		type: types.GET_SCROLL_POSITION,
+		payload: {
+			scrollX: window.scrollX,
+			scrollY: window.scrollY
+		}
 	}
-});
+};
 
 export default {
 	getScrollPosition

--- a/app/state/mouse/dragAndDrop/duck/actions.js
+++ b/app/state/mouse/dragAndDrop/duck/actions.js
@@ -1,0 +1,50 @@
+import types from './types';
+
+function createDraggable(dragId:string, zone:string, inZone:bool = false) {
+	return {
+		type: types.CREATE_DRAGGABLE,
+		payload: {
+			id: dragId,
+			zone: zone,
+			inZone: inZone
+		}
+	}
+};
+
+function createDropZone(zoneId:string) {
+	return {
+		type: types.CREATE_DROP_ZONE,
+		payload: {
+			id: zoneId,
+			mouseOverZone: false
+		}
+	}
+};
+
+function selectDraggable(dragId:string = null) {
+	return {
+		type: types.SELECT_DRAGGABLE,
+		payload: dragId
+	}
+};
+
+function selectDropZone(zoneId:string = null) {
+	return {
+		type: types.SELECT_DROP_ZONE,
+		payload: zoneId
+	}
+};
+
+function draggableDropped() {
+	return {
+		type: types.DRAGGABLE_DROPPED
+	}
+};
+
+export default {
+	createDraggable,
+	createDropZone,
+	selectDraggable,
+	selectDropZone,
+	draggableDropped
+};

--- a/app/state/mouse/dragAndDrop/duck/reducers.js
+++ b/app/state/mouse/dragAndDrop/duck/reducers.js
@@ -1,0 +1,116 @@
+import types from './types';
+
+const dragAndDropReducer = (state = {
+	zones: {},
+	draggables: {},
+	currentDraggable: null,
+	currentDropZone: null,
+	canDrop: false
+}, action) => {
+	switch(action.type) {
+		case types.CREATE_DRAGGABLE: {
+			var name = action.payload.id
+			state = {
+				...state,
+				draggables: {
+					...state.draggables,
+					[name]: action.payload
+				}
+			}
+			break;
+		}
+		case types.CREATE_DROP_ZONE: {
+			var name = action.payload.id
+			state = {
+				...state,
+				zones: {
+					...state.zones,
+					[name]: action.payload
+				}
+			}
+			break;
+		}
+		case types.SELECT_DRAGGABLE: {
+			state = {
+				...state,
+				currentDraggable: action.payload
+			}
+
+			var zoneCheck = null;
+
+			if(state.currentDraggable != null) {
+				zoneCheck = state.draggables[state.currentDraggable].zone;
+			}
+			else
+			{
+				state = {
+					...state,
+					currentDropZone: null,
+					canDrop: false
+				}
+			}
+
+			if(!state.canDrop && zoneCheck != null && zoneCheck === state.currentDropZone) {
+				state = {
+					...state,
+					canDrop: true
+				}
+			}
+			else
+			{
+				state = {
+					...state,
+					canDrop: false
+				}
+			}
+
+			break;
+		}
+		case types.SELECT_DROP_ZONE: {
+			state = {
+				...state,
+				currentDropZone: action.payload
+			}
+
+			var zoneCheck = null;
+
+			if(state.currentDraggable != null) {
+				zoneCheck = state.draggables[state.currentDraggable].zone;
+			}
+			else
+			{
+				state = {
+					...state,
+					canDrop: false
+				}
+			}
+
+			if(!state.canDrop && zoneCheck != null && zoneCheck === state.currentDropZone) {
+				state = {
+					...state,
+					canDrop: true
+				}
+			}
+			else
+			{
+				state = {
+					...state,
+					canDrop: false
+				}
+			}
+
+			break;
+		}
+		case types.DRAGGABLE_DROPPED: {
+			state = {
+				...state,
+				currentDraggable: null,
+				canDrop: false
+			}
+			break;
+		}
+	}
+	return state;
+}
+
+export default dragAndDropReducer;

--- a/app/state/mouse/dragAndDrop/duck/types.js
+++ b/app/state/mouse/dragAndDrop/duck/types.js
@@ -1,0 +1,13 @@
+const CREATE_DRAGGABLE = "mouse/dragAndDrop/duck/CREATE_DRAGGABLE";
+const CREATE_DROP_ZONE = "mouse/dragAndDrop/duck/CREATE_DROP_ZONE";
+const SELECT_DRAGGABLE = "mouse/dragAndDrop/duck/SELECT_DRAGGABLE";
+const SELECT_DROP_ZONE = "mouse/dragAndDrop/duck/SELECT_DROP_ZONE";
+const DRAGGABLE_DROPPED = "mouse/dragAndDrop/duck/DRAGGABLE_DROPPED";
+
+export default {
+	CREATE_DRAGGABLE,
+	CREATE_DROP_ZONE,
+	SELECT_DRAGGABLE,
+	SELECT_DROP_ZONE,
+	DRAGGABLE_DROPPED
+};

--- a/app/state/mouse/dragAndDrop/index.js
+++ b/app/state/mouse/dragAndDrop/index.js
@@ -1,0 +1,6 @@
+import reducer from './duck/reducers';
+
+export { default as dragAndDropActions } from './duck/actions';
+export { default as dragAndDropTypes } from './duck/types';
+
+export default reducer;

--- a/app/state/mouse/tracking/duck/actions.js
+++ b/app/state/mouse/tracking/duck/actions.js
@@ -1,0 +1,22 @@
+import types from './types';
+
+function trackMousePosition(posX, posY) {
+	return {
+		type: types.TRACK_MOUSE_POSITION,
+		payload: {
+			x: posX,
+			y: posY
+		}
+	}
+};
+
+function clearMousePosition() {
+	return {
+		type: types.CLEAR_MOUSE_POSITION
+	}
+}
+
+export default {
+	trackMousePosition,
+	clearMousePosition
+};

--- a/app/state/mouse/tracking/duck/reducers.js
+++ b/app/state/mouse/tracking/duck/reducers.js
@@ -1,0 +1,34 @@
+import types from './types';
+
+const mouseTrackingReducer = (state = {
+	position: {
+		x: null,
+		y: null
+	}
+}, action) => {
+	switch(action.type) {
+		case types.TRACK_MOUSE_POSITION: {
+			state = {
+				...state,
+				position: {
+					x: action.payload.x,
+					y: action.payload.y
+				}
+			}
+			break;
+		}
+		case types.CLEAR_MOUSE_POSITION: {
+			state = {
+				state,
+				position: {
+					x: null,
+					y: null
+				}
+			}
+			break;
+		}
+	}
+	return state;
+}
+
+export default mouseTrackingReducer;

--- a/app/state/mouse/tracking/duck/types.js
+++ b/app/state/mouse/tracking/duck/types.js
@@ -1,0 +1,7 @@
+const TRACK_MOUSE_POSITION = "mouse/tracking/duck/TRACK_MOUSE_POSITION";
+const CLEAR_MOUSE_POSITION = "mouse/tracking/duck/CLEAR_MOUSE_POSITION";
+
+export default {
+	TRACK_MOUSE_POSITION,
+	CLEAR_MOUSE_POSITION
+};

--- a/app/state/mouse/tracking/index.js
+++ b/app/state/mouse/tracking/index.js
@@ -1,0 +1,6 @@
+import reducer from './duck/reducers';
+
+export { default as mouseTrackingActions } from './duck/actions';
+export { default as mouseTrackingTypes } from './duck/types';
+
+export default reducer;

--- a/app/state/reducers.js
+++ b/app/state/reducers.js
@@ -3,9 +3,13 @@ import { combineReducers } from 'redux';
 import initialReducer from './initial';
 import scrollEventReducer from './events/scroll';
 import windowEventReducer from './events/window';
+import mouseTrackingReducer from './mouse/tracking';
+import dragAndDropReducer from './mouse/dragAndDrop';
 
 export default combineReducers({
 	initialState: initialReducer,
 	scrollState: scrollEventReducer,
-	windowState: windowEventReducer
+	windowState: windowEventReducer,
+	mouseState: mouseTrackingReducer,
+	dragAndDropState: dragAndDropReducer
 });

--- a/portfolio-site.sublime-workspace
+++ b/portfolio-site.sublime-workspace
@@ -4,16 +4,16 @@
 		"selected_items":
 		[
 			[
+				"inner",
+				"innerWidth\t.innerWidth()"
+			],
+			[
 				"d",
 				"duck"
 			],
 			[
 				"time",
 				"timer"
-			],
-			[
-				"inner",
-				"innerHeight\t.innerHeight()"
 			],
 			[
 				"back",
@@ -520,66 +520,46 @@
 	"buffers":
 	[
 		{
-			"contents": "import React from 'react';\nimport { bindActionCreators } from 'redux';\nimport { connect } from 'react-redux';\n\nimport {  }\n\nimport TimedComponent from './TimedComponent';\n\nconst TimedContainer = React.createClass({\n\t// getInitialState() {\n\t// \treturn {\n\t// \t\tdelay: 0,\n\t// \t\telapsedTime: 0,\n\t// \t}\n\t// },\n\n\t// propTypes: {\n\t// \ttcStart: React.PropTypes.number,\n\t// \ttcIncrement: React.PropTypes.number,\n\t// \ttcDuration: React.PropTypes.number.isRequired\n\t// },\n\n\t// getDefaultProps() {\n\t// \treturn {\n\t// \t\ttcStart: 0,\n\t// \t\ttcIncrement: 1000\n\t// \t}\n\t// },\n\n\t// componentWillMount() {\n\t// \tthis.delay = 0;\n\t// \tthis.elapsedTime = 0;\n\t// },\n\n\t// componentDidMount() {\n\t// \tthis.initializeTimer();\n\t// },\n\n\t// componentWillUnmount() {\n\t// \tthis.stopTimer();\n\t// },\n\n\t// initializeTimer() {\n\t// \tthis.timer = setInterval(this.timeCounter, this.props.tcIncrement);\n\t// },\n\n\t// timeCounter() {\n\t// \tif(this.state.delay < this.props.tcStart) {\n\t// \t\tthis.setState({\n\t// \t\t\t...this.state,\n\t// \t\t\tdelay: this.state.delay + 1\n\t// \t\t});\n\t// \t}\n\t// \telse\n\t// \t{\n\t// \t\tthis.setState({\n\t// \t\t\t...this.state,\n\t// \t\t\telapsedTime: this.state.elapsedTime + 1\n\t// \t\t});\n\t// \t}\n\n\t// \tif(this.state.elapsedTime >= this.props.tcDuration) {\n\t// \t\tthis.stopTimer();\n\t// \t}\n\t// },\n\n\t// stopTimer() {\n\t// \tclearInterval(this.timer);\n\t// \tthis.stopped = true;\n\t// },\t\n\n\t// render() {\n\t// \treturn (\n\t// \t\t<TimedComponent time={this.state.elapsedTime} stop={this.state.elapsedTime >= this.props.tcDuration || this.stopped}>\n\t// \t\t\t{this.props.children}\n\t// \t\t</TimedComponent>\n\t// \t)\n\t// }\n});\n\nexport default TimedContainer;",
-			"file": "app/components/Containers/EventContainers/TimedContainer/index.js",
-			"file_size": 1399,
-			"file_write_time": 131327017178084365,
+			"file": "app/components/Pages/Portfolio/index.js",
 			"settings":
 			{
-				"buffer_size": 1596,
-				"line_ending": "Windows"
-			}
-		},
-		{
-			"file": "app/components/Containers/EventContainers/TimedContainer/TimedComponent/index.js",
-			"settings":
-			{
-				"buffer_size": 178,
+				"buffer_size": 449,
 				"encoding": "UTF-8",
 				"line_ending": "Windows"
 			}
 		},
 		{
-			"file": "app/state/events/timer/index.js",
+			"file": "app/components/Containers/EventContainers/Draggable/index.js",
 			"settings":
 			{
-				"buffer_size": 168,
+				"buffer_size": 2280,
 				"encoding": "UTF-8",
 				"line_ending": "Windows"
 			}
 		},
 		{
-			"file": "app/state/events/timer/duck/actions.js",
+			"file": "app/components/Containers/EventContainers/DragAndDrop/DropZone/index.js",
 			"settings":
 			{
-				"buffer_size": 406,
+				"buffer_size": 1957,
 				"encoding": "UTF-8",
 				"line_ending": "Windows"
 			}
 		},
 		{
-			"file": "app/state/events/timer/duck/types.js",
+			"file": "app/components/Containers/EventContainers/DragAndDrop/DragContainer/index.js",
 			"settings":
 			{
-				"buffer_size": 216,
+				"buffer_size": 1223,
 				"encoding": "UTF-8",
 				"line_ending": "Windows"
 			}
 		},
 		{
-			"file": "app/state/events/timer/duck/reducers.js",
+			"file": "app/components/Containers/EventContainers/StickyEventContainer/index.js",
 			"settings":
 			{
-				"buffer_size": 541,
-				"encoding": "UTF-8",
-				"line_ending": "Windows"
-			}
-		},
-		{
-			"file": "app/components/app.js",
-			"settings":
-			{
-				"buffer_size": 1806,
+				"buffer_size": 1540,
 				"line_ending": "Windows"
 			}
 		}
@@ -642,53 +622,70 @@
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Components",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/EventContainers",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/EventContainers/DragAndDrop",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/EventContainers/DragAndDrop/DragContainer",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/EventContainers/DragAndDrop/DropZone",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/EventContainers/Draggable",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/EventContainers/StickyEventContainer",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/EventContainers/TimedContainer",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/LayoutContainers",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/LayoutContainers/Grid",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/LayoutContainers/Grid/GridComponents",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/LayoutContainers/Grid/GridComponents/Row",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Pages",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Pages/Portfolio",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/scroll",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/scroll/duck",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/timer",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/timer/duck",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/styles",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/styles/navbar"
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/mouse",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/mouse/dragAndDrop",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/mouse/dragAndDrop/duck",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/mouse/tracking",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/mouse/tracking/duck",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/styles"
 	],
 	"file_history":
 	[
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/reducers.js",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Pages/Home/index.js",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/LayoutContainers/Grid/GridComponents/Row/index.js",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/LayoutContainers/Grid/index.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/EventContainers/DragAndDrop/DropZone/index.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/index.js",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/styles/navbar/navbar.less",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/mouse/dragAndDrop/duck/reducers.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/mouse/dragAndDrop/duck/types.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/mouse/dragAndDrop/duck/actions.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/EventContainers/Draggable/index.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/mouse/tracking/duck/reducers.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/mouse/tracking/duck/types.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/mouse/tracking/duck/actions.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/mouse/dragAndDrop/index.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/reducers.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/EventContainers/StickyEventContainer/index.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/app.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/mouse/duck/reducers.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/mouse/duck/actions.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/mouse/duck/types.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Pages/Portfolio/index.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/mouse/index.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/scroll/index.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/scroll/duck/reducers.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/scroll/duck/actions.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/scroll/duck/types.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Layout/Navbar/index.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/mouse/duck/reducers.jas",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Pages/Home/index.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Pages/index.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Components/NavigationComponents/NavigationListComponent/index.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/styles/navbar/navbar.less",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/EventContainers/ScrollLoader/ScrollLoad/index.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/EventContainers/ScrollLoader/index.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/EventContainers/TimedContainer/index.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/LayoutContainers/Grid/GridComponents/Row/index.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/EventContainers/TimedContainer/TimedComponent/index.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/timer/duck/reducers.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/timer/duck/types.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/timer/duck/actions.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/timer/index.js",
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/LayoutContainers/Grid/index.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Layout/index.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Layout/Header/index.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Layout/Footer/index.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/LayoutContainers/ResponsiveContainer/index.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/LayoutContainers/Grid/GridComponents/Col/index.js",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/EventContainers/StickyEventContainer/index.js",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/EventContainers/ScrollLoader/index.js",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/EventContainers/ScrollLoader/ScrollLoad/index.js",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Components/NavigationComponents/NavigationListComponent/index.js",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/timer/duck/reducers.js",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/timer/duck/actions.js",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/timer/duck/types.js",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/timer/index.js",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/scroll/duck/types.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/window/duck/types.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/EventContainers/AnimationContainer/index.js",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/scroll/duck/actions.js",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/scroll/duck/reducers.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Pages/navLinks.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/index.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/routes.js",
@@ -696,7 +693,6 @@
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/scrollLoader/duck/types.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/scrollLoader/duck/actions.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/scrollLoader/index.js",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Pages/Portfolio/index.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/styles/index.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/window/duck/actions.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/package.json",
@@ -707,7 +703,6 @@
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/LayoutContainers/GridContainer/index.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/dist/index.html",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/styles/app/app.less",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Pages/index.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/LayoutContainers/PageContainer/index.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/styles/page/page.less",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/styles/page/index.js",
@@ -725,7 +720,6 @@
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/styles/app/index.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Containers/LayoutContainers/LiveGridContainer/index.js",
 		"/X/Digital-Brochure/DigitalBrochure/pages/Book1-InteractiveElements/video.flv",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/scroll/index.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/events/window/index.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/dom/contentBox/duck/types.js",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/dom/contentBox/duck/reducers.js",
@@ -774,23 +768,7 @@
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/common/styles/app.css",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/common/styles/app.css.map",
 		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Pages/_common/styles/page/page.less",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Pages/_common/styles/styles.less",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Pages/_common/styles/page/page.scss",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Layout/_common/styles/navbar.scss",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Layout/_common/styles/navbar.less",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Layout/_common/styles/navbar.css",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Layout/_common/styles/index.css",
-		"/C/xampp/htdocs/amt/assets/css/sass/styles.scss",
-		"/C/xampp/htdocs/amt/assets/css/styles.css",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Pages/Master/index.js",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Pages/_common/styles/page.css",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Layout/Navbar/styles/styles.css",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/common/styles/global.css",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Pages/routeList.js",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/routes.js",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/test/test.js",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/test-feature/duck/reducers.js",
-		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/state/test-feature/duck/actions.js"
+		"/C/Users/Matthew/Documents/GitHub/site/portfolio-site/app/components/Pages/_common/styles/styles.less"
 	],
 	"find":
 	{
@@ -810,6 +788,56 @@
 		"case_sensitive": false,
 		"find_history":
 		[
+			"thisDiv",
+			"dragId",
+			"Width",
+			"top",
+			"Zone",
+			"Track",
+			"track",
+			"TRACK_MOUSE_POSITION",
+			"TRACK",
+			"canDraggableDrop",
+			"CAN_DRAGGABLE_DROP",
+			"DRAGGABLE_CAN_DROP",
+			"tryToDrop",
+			"TRY_TO_DROP",
+			"SELECT_DRAGGABLE",
+			"draggables",
+			"thisZone",
+			"i",
+			"ZONE",
+			"zone",
+			"EXITING_DROP_ZONE",
+			"ENTERING_DROP_ZONE",
+			"IS_OVER_DROP_ZONE",
+			"SELECTED_DRAGGABLE",
+			"IS_OVER_DROP_ZONE",
+			"DragContainer",
+			"createDropZone",
+			"DropZone",
+			"state",
+			"id",
+			"GET_ZONE_ID",
+			"id",
+			"TRY_TO_DROP",
+			"ATTEMPT_TO_DROP",
+			"COMPARE_DRAG_AND_DROP",
+			"CREATE_DRAG_AND_DROP",
+			"50",
+			"startDragging",
+			"page",
+			"mouseEvent",
+			"event",
+			"window",
+			"scrollEvent",
+			"getMousePosition",
+			"MOUSE_WILL_BE_TRACKED",
+			"TRACKING_MOUSE",
+			"TRACK_MOUSE_POSITION",
+			"ReactTransitionGroup",
+			"div",
+			"tcStart",
 			"baseTime",
 			"timerTick",
 			"createNewTimer",
@@ -887,57 +915,7 @@
 			"this.colWidth",
 			"gridCount",
 			"windowEvent",
-			"Actions",
-			"this",
-			"sameWidthAsPrev",
-			"minColWidth",
-			"handleWindowResize",
-			"col.props.blocks",
-			"width",
-			"prevColWidth",
-			"colGroups",
-			"col",
-			"colGroups",
-			"120",
-			"checkColumnWidths",
-			"handleWindowResize",
-			"count",
-			"Row",
-			"div",
-			"ScrollPosition",
-			"scroll",
-			"scrollState",
-			"PageContainer",
-			"GridContainer",
-			"PageContainer",
-			"GridRow",
-			"Column",
-			"GridColumn",
-			"dataWidth",
-			"colWidth",
-			"row.props.children.length",
-			"GridRow",
-			"Grid",
-			"Live",
-			"padding",
-			"Padding",
-			"getElementWidth",
-			"getWindowSize",
-			"div",
-			"row",
-			"Row",
-			"child",
-			"rows",
-			"GridColumn",
-			"div",
-			"Row",
-			"scroll",
-			"windowResized",
-			"WINDOW_RESIZED",
-			"window",
-			"scrollY",
-			"window",
-			"Window"
+			"Actions"
 		],
 		"highlight": true,
 		"in_selection": false,
@@ -955,93 +933,28 @@
 	"groups":
 	[
 		{
-			"selected": 0,
+			"selected": 1,
 			"sheets":
 			[
 				{
 					"buffer": 0,
-					"file": "app/components/Containers/EventContainers/TimedContainer/index.js",
+					"file": "app/components/Pages/Portfolio/index.js",
 					"semi_transient": false,
 					"settings":
 					{
-						"buffer_size": 1596,
+						"buffer_size": 449,
 						"regions":
 						{
 						},
 						"selection":
 						[
 							[
-								517,
-								517
+								375,
+								375
 							]
 						],
 						"settings":
 						{
-							"open_with_edit": true,
-							"syntax": "Packages/Babel/JavaScript (Babel).sublime-syntax"
-						},
-						"translation.x": 0.0,
-						"translation.y": 0.0,
-						"zoom_level": 1.0
-					},
-					"stack_index": 5,
-					"type": "text"
-				},
-				{
-					"buffer": 1,
-					"file": "app/components/Containers/EventContainers/TimedContainer/TimedComponent/index.js",
-					"semi_transient": false,
-					"settings":
-					{
-						"buffer_size": 178,
-						"regions":
-						{
-						},
-						"selection":
-						[
-							[
-								178,
-								178
-							]
-						],
-						"settings":
-						{
-							"open_with_edit": true,
-							"syntax": "Packages/Babel/JavaScript (Babel).sublime-syntax"
-						},
-						"translation.x": 0.0,
-						"translation.y": 0.0,
-						"zoom_level": 1.0
-					},
-					"stack_index": 6,
-					"type": "text"
-				}
-			]
-		},
-		{
-			"selected": 3,
-			"sheets":
-			[
-				{
-					"buffer": 2,
-					"file": "app/state/events/timer/index.js",
-					"semi_transient": false,
-					"settings":
-					{
-						"buffer_size": 168,
-						"regions":
-						{
-						},
-						"selection":
-						[
-							[
-								168,
-								168
-							]
-						],
-						"settings":
-						{
-							"open_with_edit": true,
 							"syntax": "Packages/Babel/JavaScript (Babel).sublime-syntax"
 						},
 						"translation.x": 0.0,
@@ -1052,49 +965,84 @@
 					"type": "text"
 				},
 				{
-					"buffer": 3,
-					"file": "app/state/events/timer/duck/actions.js",
+					"buffer": 1,
+					"file": "app/components/Containers/EventContainers/Draggable/index.js",
 					"semi_transient": false,
 					"settings":
 					{
-						"buffer_size": 406,
+						"buffer_size": 2280,
 						"regions":
 						{
 						},
 						"selection":
 						[
 							[
-								143,
-								143
+								1849,
+								1849
 							]
 						],
 						"settings":
 						{
-							"open_with_edit": true,
-							"syntax": "Packages/Babel/JavaScript (Babel).sublime-syntax"
+							"syntax": "Packages/Babel/JavaScript (Babel).sublime-syntax",
+							"translate_tabs_to_spaces": false
 						},
 						"translation.x": 0.0,
-						"translation.y": 0.0,
+						"translation.y": 540.0,
 						"zoom_level": 1.0
 					},
-					"stack_index": 2,
+					"stack_index": 0,
 					"type": "text"
 				},
 				{
-					"buffer": 4,
-					"file": "app/state/events/timer/duck/types.js",
+					"buffer": 2,
+					"file": "app/components/Containers/EventContainers/DragAndDrop/DropZone/index.js",
 					"semi_transient": false,
 					"settings":
 					{
-						"buffer_size": 216,
+						"buffer_size": 1957,
 						"regions":
 						{
 						},
 						"selection":
 						[
 							[
-								214,
-								214
+								1546,
+								1546
+							]
+						],
+						"settings":
+						{
+							"syntax": "Packages/Babel/JavaScript (Babel).sublime-syntax",
+							"translate_tabs_to_spaces": false
+						},
+						"translation.x": 0.0,
+						"translation.y": 1080.0,
+						"zoom_level": 1.0
+					},
+					"stack_index": 4,
+					"type": "text"
+				}
+			]
+		},
+		{
+			"selected": 1,
+			"sheets":
+			[
+				{
+					"buffer": 3,
+					"file": "app/components/Containers/EventContainers/DragAndDrop/DragContainer/index.js",
+					"semi_transient": false,
+					"settings":
+					{
+						"buffer_size": 1223,
+						"regions":
+						{
+						},
+						"selection":
+						[
+							[
+								579,
+								579
 							]
 						],
 						"settings":
@@ -1110,49 +1058,20 @@
 					"type": "text"
 				},
 				{
-					"buffer": 5,
-					"file": "app/state/events/timer/duck/reducers.js",
+					"buffer": 4,
+					"file": "app/components/Containers/EventContainers/StickyEventContainer/index.js",
 					"semi_transient": false,
 					"settings":
 					{
-						"buffer_size": 541,
+						"buffer_size": 1540,
 						"regions":
 						{
 						},
 						"selection":
 						[
 							[
-								387,
-								387
-							]
-						],
-						"settings":
-						{
-							"open_with_edit": true,
-							"syntax": "Packages/Babel/JavaScript (Babel).sublime-syntax"
-						},
-						"translation.x": 0.0,
-						"translation.y": 0.0,
-						"zoom_level": 1.0
-					},
-					"stack_index": 0,
-					"type": "text"
-				},
-				{
-					"buffer": 6,
-					"file": "app/components/app.js",
-					"semi_transient": false,
-					"settings":
-					{
-						"buffer_size": 1806,
-						"regions":
-						{
-						},
-						"selection":
-						[
-							[
-								0,
-								0
+								899,
+								899
 							]
 						],
 						"settings":
@@ -1160,11 +1079,11 @@
 							"syntax": "Packages/Babel/JavaScript (Babel).sublime-syntax",
 							"translate_tabs_to_spaces": false
 						},
-						"translation.x": 0.0,
-						"translation.y": 0.0,
+						"translation.x": -0.0,
+						"translation.y": 480.0,
 						"zoom_level": 1.0
 					},
-					"stack_index": 4,
+					"stack_index": 2,
 					"type": "text"
 				}
 			]
@@ -1254,7 +1173,7 @@
 		],
 		"width": 0.0
 	},
-	"selected_group": 1,
+	"selected_group": 0,
 	"settings":
 	{
 	},


### PR DESCRIPTION
I created a DragAndDropState store in Redux to manage DragContainers
(soon to be merged with and renamed to Draggable) and DropZone React
containers.

Draggables require props:
dragId (string): unique name for the Draggable
zoneId (string): id of the DropZone it is permitted to drop into.

DropZone requires prop:
zoneId (string): unique name. Determines what Draggables can be dropped
there.